### PR TITLE
Cache & HTTP Client DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 PHP API Wrapper for [Open Food Facts](https://openfoodfacts.org/), the open database about food.
 
 [![Project Status](http://opensource.box.com/badges/active.svg)](http://opensource.box.com/badges)
-[![Build Status](https://travis-ci.org/openfoodfacts/openfoodfacts-php.svg?branch=master)](https://travis-ci.org/openfoodfacts/openfoodfacts-php) [![Stories in Ready](https://badge.waffle.io/openfoodfacts/openfoodfacts-php.svg?label=ready&title=Ready)](https://waffle.io/openfoodfacts/openfoodfacts-php)
+[![Build Status](https://travis-ci.org/openfoodfacts/openfoodfacts-php.svg?branch=master)](https://travis-ci.org/openfoodfacts/openfoodfacts-php)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/openfoodfacts/openfoodfacts-php.svg)](https://isitmaintained.com/project/openfoodfacts/openfoodfacts-php "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/openfoodfacts/openfoodfacts-php.svg)](https://isitmaintained.com/project/openfoodfacts/openfoodfacts-php "Percentage of issues still open")
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "guzzlehttp/guzzle": "^6.3",
     "psr/log": "^1.0",
     "psr/simple-cache": "^1.0",
-    "ext-json": "*"
+    "ext-json": "*",
+    "ext-curl": "*"
   },
   "autoload": {
     "psr-4": {
@@ -33,6 +34,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",
+    "symfony/cache": "^4.3",
     "monolog/monolog": "^1.23",
     "ext-gd": ">=7.2"
   }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
   "require": {
     "php": ">=7.1",
     "guzzlehttp/guzzle": "^6.3",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0",
+    "psr/simple-cache": "^1.0",
+    "ext-json": "*"
   },
   "autoload": {
     "psr-4": {

--- a/examples/01-basic_api_usage/cached_example.php
+++ b/examples/01-basic_api_usage/cached_example.php
@@ -2,7 +2,9 @@
 include '../../vendor/autoload.php';
 $logger = new \Monolog\Logger('test');
 $httpClient = new \GuzzleHttp\Client();
-
-$api = new \OpenFoodFacts\Api('food', 'world', $logger, $httpClient);
+// the PSR-6 cache object that you want to use
+$psr6Cache = new FilesystemAdapter();
+$psr16Cache = new Psr16Cache($psr6Cache);
+$api = new \OpenFoodFacts\Api('food', 'world', $logger, $httpClient, $psr16Cache);
 $product = $api->getProduct(rand(1, 50));
 $e =1;

--- a/examples/01-basic_api_usage/cached_example.php
+++ b/examples/01-basic_api_usage/cached_example.php
@@ -1,0 +1,8 @@
+<?php
+include '../../vendor/autoload.php';
+$logger = new \Monolog\Logger('test');
+$httpClient = new \GuzzleHttp\Client();
+
+$api = new \OpenFoodFacts\Api('food', 'world', $logger, $httpClient);
+$product = $api->getProduct(rand(1, 50));
+$e =1;

--- a/src/Api.php
+++ b/src/Api.php
@@ -132,14 +132,9 @@ class Api
         CacheInterface $cacheInterface = null
     )
     {
-        if (empty($cacheInterface)) {
-            $this->httpClient = new Client();
-        } else {
-            $this->httpClient = $clientInterface;
-        }
-
         $this->cache        = $cacheInterface;
         $this->logger       = $logger ?? new NullLogger();
+        $this->httpClient   = $clientInterface ?? new Client();
 
         $this->geoUrl     = sprintf(self::LIST_API[$api], $geography);
         $this->geography  = $geography;

--- a/src/Api.php
+++ b/src/Api.php
@@ -129,8 +129,6 @@ class Api
         $this->cache        = $cacheInterface;
         $this->logger       = $logger ?? new NullLogger();
 
-        //TODO : throw Exception if not found
-
         $this->geoUrl     = sprintf(self::LISTAPI[$api], $geography);
         $this->geography  = $geography;
         $this->currentAPI = $api;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,7 +2,9 @@
 
 namespace OpenFoodFacts;
 
-class Collection implements \Iterator
+use Iterator;
+
+class Collection implements Iterator
 {
 
     private $listDocuments  = null;
@@ -12,7 +14,7 @@ class Collection implements \Iterator
     private $pageSize       = null;
 
     /**
-     * initilization of the collection
+     * initialization of the collection
      * @param array|null $data the raw data
      * @param string|null $api  this information help to type the collection  (not use yet)
      */

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -3,10 +3,12 @@
 namespace OpenFoodFacts\Exception;
 
 
+use Exception;
+
 /**
  * Just an exception class for the try catch
  */
-class BadRequestException extends \Exception
+class BadRequestException extends Exception
 {
 
 }

--- a/src/Exception/ProductNotFoundException.php
+++ b/src/Exception/ProductNotFoundException.php
@@ -3,10 +3,12 @@
 namespace OpenFoodFacts\Exception;
 
 
+use Exception;
+
 /**
  * Just an exception class for the try catch
  */
-class ProductNotFoundException extends \Exception
+class ProductNotFoundException extends Exception
 {
 
 }

--- a/src/FilesystemTrait.php
+++ b/src/FilesystemTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenFoodFacts;
+
+trait FilesystemTrait
+{
+    function recursiveDeleteDirectory($dir)
+    {
+        if (is_dir($dir)) {
+            $objects = scandir($dir);
+            foreach ($objects as $object) {
+                if ($object != "." && $object != "..") {
+                    if (is_dir($dir . "/" . $object)) {
+                        $this->recursiveDeleteDirectory($dir . "/" . $object);
+                    } else {
+                        unlink($dir . "/" . $object);
+                    }
+                }
+            }
+            rmdir($dir);
+        }
+    }
+}

--- a/tests/ApiPetTest.php
+++ b/tests/ApiPetTest.php
@@ -1,4 +1,6 @@
 <?php
+
+use OpenFoodFacts\FilesystemTrait;
 use PHPUnit\Framework\TestCase;
 
 use OpenFoodFacts\Api;
@@ -17,6 +19,8 @@ use Monolog\Handler\StreamHandler;
 class ApiPetTest extends TestCase
 {
 
+    use FilesystemTrait;
+
     private $api;
 
     protected function setUp()
@@ -24,9 +28,9 @@ class ApiPetTest extends TestCase
         $log = new Logger('name');
         $log->pushHandler(new StreamHandler('log/test.log'));
 
-        $this->api = new Api('pet','fr',$log);
+        $this->api = new Api('pet', 'fr', $log);
 
-        foreach(glob('tests/images/*') as $file){
+        foreach (glob('tests/images/*') as $file) {
             unlink($file);
         }
     }
@@ -45,10 +49,13 @@ class ApiPetTest extends TestCase
     public function testApiAddImage()
     {
         try {
-            $this->api->uploadImage('7613035799738','fronts','nothing');
+            $this->api->uploadImage('7613035799738', 'fronts', 'nothing');
             $this->assertTrue(false);
         } catch (BadRequestException $e) {
-            $this->assertEquals($e->getMessage(),'not Available yet');
+            $this->assertEquals($e->getMessage(), 'not Available yet');
+            $this->markTestSkipped(
+                $e->getMessage()
+            );
         }
 
     }
@@ -56,12 +63,17 @@ class ApiPetTest extends TestCase
     public function testApiSearch()
     {
 
-        $collection = $this->api->search('chat',3,30);
+        $collection = $this->api->search('chat', 3, 30);
 
         $this->assertEquals(get_class($collection), Collection::class);
         $this->assertEquals($collection->pageCount(), 30);
         $this->assertGreaterThan(100, $collection->searchCount());
 
+    }
+
+    protected function tearDown()
+    {
+        $this->recursiveDeleteDirectory('tests/tmp');
     }
 
 }


### PR DESCRIPTION
This PR adds support for 

- Injecting an own httpClient
     - with independent config, thus allowing to set a custom header as asked for in #11 (this may be 
       "enforced" in the constructor in future?)
- Injecting PSR-16 Cache Interface (for those wanting to use PSR-6: there are several libraries to make 
   them interchangable. would suggest closing #12 
- additonal tests 
- overall improvements of Code Style and fixing some typos
- raised version number to 0.2.1 accordingly to semantic versioning (semver.org) via tag as this is new functionality 


