### PR TITLE
Specific Document Types and Raw Data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require openfoodfacts/openfoodfacts-php
 This is the most basic way of creating the API:
 ```php
 $api = new OpenFoodFacts\Api('food','fr');
-$prd = $api->getProduct('3057640385148');
+$product = $api->getProduct('3057640385148');
 ```
 In the example above you access the "food" database, limited to the French language/country scope. 
 The first parameter is either 
@@ -35,6 +35,18 @@ The second parameter decides the language/country scope of the chosen database: 
 For more details on this topic: see the [API Documentation](https://en.wiki.openfoodfacts.org/API/Read#Countries_and_Language_of_the_Response)
 
 These are all the parameters you really need for basic usage.
+
+As return types for ```$api->getProduct``` you get an ```Document::class``` Object. 
+This may also be an Object of Type  ```FoodProduct::class```,```PetProduct::class```, ```BeautyProduct::class``` depending on which API you are creating.
+These objects inherit from the more generic ```Document::class```
+
+In the example above, we use the 'food' API and there will get a ```FoodProduct::class```
+
+For getting a first overview the ```Document::class``` has a function to return an array representation(sorted) for a first start. 
+```php
+$product = $api->getProduct('3057640385148');
+$productDataAsArray = $product->getData();
+```
 
 
 #### Optional Parameters

--- a/README.md
+++ b/README.md
@@ -17,16 +17,44 @@ composer require openfoodfacts/openfoodfacts-php
 ```
 
 ## Usage
-Is possible using API without Wrapper.
+This is the most basic way of creating the API:
 ```php
-$api = new OpenFoodFacts\Api('food','fr-en',$log);
+$api = new OpenFoodFacts\Api('food','fr');
 $prd = $api->getProduct('3057640385148');
 ```
+In the example above you access the "food" database, limited to the French language/country scope. 
+The first parameter is either 
+ - "food"
+ - "beauty" or 
+ - "pet"
+ 
+to decide which product database you want to use.
 
+The second parameter decides the language/country scope of the chosen database: f.e. "world" or "de" or "fr". 
+
+For more details on this topic: see the [API Documentation](https://en.wiki.openfoodfacts.org/API/Read#Countries_and_Language_of_the_Response)
+
+These are all the parameters you really need for basic usage.
+
+
+##### Optional Parameters
+The other parameters are optional and for a more sophisticated use of the api (from a software development point of view):
+
+LoggerInterface: A logger which decieds where to log errors to (file, console , etc) 
+
+see: [PSR-3 Loggerinterface](https://www.php-fig.org/psr/psr-3/)
+
+ClientInterface: The HTTP Client - to adjust the connection configs to your needs and more 
+
+see: [Guzzle HTTP Client](https://packagist.org/packages/guzzlehttp/guzzle)
+
+CacheInterface: To temporarily save the results of API request to improve the performance and to reduce the load on the API- Server 
+
+see: [PSR-16 Simple Cache](https://www.php-fig.org/psr/psr-16/)
 ## Development
 
 
-## Contributing
+### Contributing
 
 1. Fork it ( https://github.com/openfoodfacts/openfoodfacts-php/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/src/Api.php
+++ b/src/Api.php
@@ -70,9 +70,10 @@ class Api
      * @var array
      */
     private const LIST_API = [
-      'food'    => 'https://%s.openfoodfacts.org',
-      'beauty'  => 'https://%s.openbeautyfacts.org',
-      'pet'     => 'https://%s.openpetfoodfacts.org'
+        'food'    => 'https://%s.openfoodfacts.org',
+        'beauty'  => 'https://%s.openbeautyfacts.org',
+        'pet'     => 'https://%s.openpetfoodfacts.org',
+        'product' => 'https://%s.openproductsfacts.org',
     ];
 
     /**
@@ -237,7 +238,7 @@ class Api
      */
     protected function createSpecificDocument(string $apiIdentifier, array $data): Document
     {
-        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Product';
+        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Document';
 
         if (class_exists($className) && is_subclass_of($className, Document::class)) {
             return new $className($data);

--- a/src/Api.php
+++ b/src/Api.php
@@ -3,11 +3,10 @@
 namespace OpenFoodFacts;
 
 
-use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\TransferStats;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\TransferStats;
 use OpenFoodFacts\Exception\BadRequestException;
 use OpenFoodFacts\Exception\ProductNotFoundException;
 use Psr\Log\LoggerInterface;
@@ -227,7 +226,28 @@ class Api
             //TODO: maybe return null here? (just throw an exception if something really went wrong?
             throw new ProductNotFoundException("Product not found", 1);
         }
-        return new Document($rawResult['product']);
+
+        return $this->createSpecificDocument($this->currentAPI, $rawResult['product']);
+    }
+
+    /**
+     * @param string $apiIdentifier
+     * @param array $data
+     * @return Document
+     */
+    protected function createSpecificDocument(string $apiIdentifier, array $data): Document
+    {
+        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Product';
+
+        if (class_exists($className) && is_subclass_of($className, Document::class)) {
+            return new $className($data);
+        } else {
+            $this->logger->error(
+                sprintf('Tried to instanciate "%s", but could not find class or class is not extending %s - Returning: %s', $className, Document::class, Document::class)
+            );
+        }
+
+        return new Document($data);
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -28,13 +28,45 @@ class Collection implements Iterator
             'page_size' => 0,
         ];
         $this->listDocuments = [];
-        foreach ($data['products'] as $document) {
-            $this->listDocuments[] = $this->createSpecificDocument($this->currentAPI, $rawResult['product']);Document($document, $api);
+
+        if (!empty($data['products'])) {
+            $currentApi = '';
+            if (null !== $api) {
+                $currentApi = $api;
+            }
+            foreach ($data['products'] as $document) {
+                $this->listDocuments[] = $this->createSpecificDocument($currentApi, $document);
+            }
         }
+
         $this->count    = $data['count'];
         $this->page     = $data['page'];
         $this->skip     = $data['skip'];
         $this->pageSize = $data['page_size'];
+    }
+
+    /**
+     * @param string $apiIdentifier
+     * @param array $data
+     * @return Document
+     */
+    protected function createSpecificDocument(string $apiIdentifier, array $data): Document
+    {
+        if ($apiIdentifier === '') {
+            return new Document($data);
+        }
+
+        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Product';
+
+        if (class_exists($className) && is_subclass_of($className, Document::class)) {
+            return new $className($data);
+        } else {
+            $this->logger->error(
+                sprintf('Tried to instanciate "%s", but could not find class or class is not extending %s - Returning: %s', $className, Document::class, Document::class)
+            );
+        }
+
+        return new Document($data);
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -56,14 +56,10 @@ class Collection implements Iterator
             return new Document($data);
         }
 
-        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Product';
+        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Document';
 
         if (class_exists($className) && is_subclass_of($className, Document::class)) {
             return new $className($data);
-        } else {
-            $this->logger->error(
-                sprintf('Tried to instanciate "%s", but could not find class or class is not extending %s - Returning: %s', $className, Document::class, Document::class)
-            );
         }
 
         return new Document($data);

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -29,7 +29,7 @@ class Collection implements Iterator
         ];
         $this->listDocuments = [];
         foreach ($data['products'] as $document) {
-            $this->listDocuments[] = new Document($document, $api);
+            $this->listDocuments[] = $this->createSpecificDocument($this->currentAPI, $rawResult['product']);Document($document, $api);
         }
         $this->count    = $data['count'];
         $this->page     = $data['page'];

--- a/src/Document.php
+++ b/src/Document.php
@@ -8,6 +8,8 @@ namespace OpenFoodFacts;
  */
 class Document
 {
+    use recursiveSortingTrait;
+
     /**
      * the whole data
      * @var array
@@ -44,6 +46,16 @@ class Document
     public function __isset(string $name):bool
     {
         return isset($this->data[$name]);
+    }
+
+    /**
+     * Returns a sorted representation of the complete Document Data
+     * @return array
+     */
+    public function getData(): array
+    {
+        $this->recursiveSortArray($this->data);
+        return $this->data;
     }
 
 }

--- a/src/Document/BeautyDocument.php
+++ b/src/Document/BeautyDocument.php
@@ -4,7 +4,7 @@ namespace OpenFoodFacts\Document;
 
 use OpenFoodFacts\Document;
 
-class BeautyProduct extends Document
+class BeautyDocument extends Document
 {
 
 }

--- a/src/Document/FoodDocument.php
+++ b/src/Document/FoodDocument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OpenFoodFacts\Document;
+
+use OpenFoodFacts\Document;
+
+class FoodDocument extends Document
+{
+
+}

--- a/src/Document/PetDocument.php
+++ b/src/Document/PetDocument.php
@@ -4,7 +4,7 @@ namespace OpenFoodFacts\Document;
 
 use OpenFoodFacts\Document;
 
-class PetProduct extends Document
+class PetDocument extends Document
 {
 
 }

--- a/src/Document/ProductDocument.php
+++ b/src/Document/ProductDocument.php
@@ -4,7 +4,7 @@ namespace OpenFoodFacts\Document;
 
 use OpenFoodFacts\Document;
 
-class FoodProduct extends Document
+class ProductDocument extends Document
 {
 
 }

--- a/src/recursiveSortingTrait.php
+++ b/src/recursiveSortingTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OpenFoodFacts;
+
+/**
+ * Trait RecursiveSortingTrait
+ */
+trait RecursiveSortingTrait
+{
+    /**
+     * @param array $arr
+     * @return bool
+     */
+    private function isAssoc(array $arr): bool
+    {
+        return array_keys($arr) !== range(0, count($arr) - 1);
+    }
+
+    /**
+     * Sorts referenced array of arrays in a recursive way for better understandability
+     * @param array $arr
+     * @see ksort
+     * @see asort
+     */
+    public function recursiveSortArray(array &$arr): void
+    {
+        if ($this->isAssoc($arr)) {
+            ksort($arr);
+        } else {
+            asort($arr);
+        }
+        foreach ($arr as &$a) {
+            if (is_array($a)) {
+                $this->recursiveSortArray($a);
+            }
+        }
+    }
+}

--- a/tests/ApiFoodCacheTest.php
+++ b/tests/ApiFoodCacheTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
-use OpenFoodFacts\Document;
 use OpenFoodFacts\Document\FoodProduct;
+use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
     BadRequestException
@@ -63,7 +63,9 @@ class ApiFoodCacheTest extends TestCase
 
         $prd = $this->api->getProduct('3057640385148');
 
-        $this->assertEquals(get_class($prd), Document::class);
+        $this->assertInstanceOf(FoodProduct::class, $prd);
+        $this->assertInstanceOf(Document::class, $prd);
+
         $this->assertTrue(isset($prd->product_name));
         $this->assertNotEmpty($prd->product_name);
 
@@ -89,7 +91,7 @@ class ApiFoodCacheTest extends TestCase
     {
 
         $collection = $this->api->getByFacets([]);
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $this->assertEquals($collection->pageCount(), 0);
 
         try {
@@ -100,7 +102,7 @@ class ApiFoodCacheTest extends TestCase
         }
 
         $collection = $this->api->getByFacets(['trace' => 'eggs', 'country' => 'france'], 3);
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $this->assertEquals($collection->pageCount(), 20);
         $this->assertEquals($collection->getPage(), 3);
         $this->assertEquals($collection->getSkip(), 40);
@@ -111,7 +113,9 @@ class ApiFoodCacheTest extends TestCase
             if ($key > 1) {
                 break;
             }
-            $this->assertEquals(get_class($doc), Document::class);
+
+            $this->assertInstanceOf(FoodProduct::class, $doc);
+            $this->assertInstanceOf(Document::class, $doc);
 
         }
 
@@ -146,11 +150,11 @@ class ApiFoodCacheTest extends TestCase
         }
 
         $collection = $this->api->getPurchase_places();
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $collection = $this->api->getPackaging_codes();
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $collection = $this->api->getEntry_dates();
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
 
         try {
             $collection = $this->api->getIngredient();

--- a/tests/ApiFoodCacheTest.php
+++ b/tests/ApiFoodCacheTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
-use OpenFoodFacts\Document\FoodProduct;
+use OpenFoodFacts\Document\FoodDocument;
 use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
@@ -63,7 +63,7 @@ class ApiFoodCacheTest extends TestCase
 
         $prd = $this->api->getProduct('3057640385148');
 
-        $this->assertInstanceOf(FoodProduct::class, $prd);
+        $this->assertInstanceOf(FoodDocument::class, $prd);
         $this->assertInstanceOf(Document::class, $prd);
 
         $this->assertTrue(isset($prd->product_name));
@@ -114,7 +114,7 @@ class ApiFoodCacheTest extends TestCase
                 break;
             }
 
-            $this->assertInstanceOf(FoodProduct::class, $doc);
+            $this->assertInstanceOf(FoodDocument::class, $doc);
             $this->assertInstanceOf(Document::class, $doc);
 
         }

--- a/tests/ApiFoodTest.php
+++ b/tests/ApiFoodTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
 use OpenFoodFacts\Document\FoodProduct;
+use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
     BadRequestException

--- a/tests/ApiFoodTest.php
+++ b/tests/ApiFoodTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
-use OpenFoodFacts\Document;
 use OpenFoodFacts\Document\FoodProduct;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
@@ -39,7 +38,8 @@ class ApiFoodTest extends TestCase
 
         $prd = $this->api->getProduct('3057640385148');
 
-        $this->assertEquals(get_class($prd), Document::class);
+        $this->assertInstanceOf(FoodProduct::class, $prd);
+        $this->assertInstanceOf(Document::class, $prd);
         $this->assertTrue(isset($prd->product_name));
         $this->assertNotEmpty($prd->product_name);
 
@@ -65,7 +65,7 @@ class ApiFoodTest extends TestCase
     {
 
         $collection = $this->api->getByFacets([]);
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $this->assertEquals($collection->pageCount(), 0);
 
         try {
@@ -76,7 +76,7 @@ class ApiFoodTest extends TestCase
         }
 
         $collection = $this->api->getByFacets(['trace' => 'eggs', 'country' => 'france'], 3);
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $this->assertEquals($collection->pageCount(), 20);
         $this->assertEquals($collection->getPage(), 3);
         $this->assertEquals($collection->getSkip(), 40);
@@ -87,7 +87,8 @@ class ApiFoodTest extends TestCase
             if ($key > 1) {
                 break;
             }
-            $this->assertEquals(get_class($doc), Document::class);
+            $this->assertInstanceOf(FoodProduct::class, $doc);
+            $this->assertInstanceOf(Document::class, $doc);
 
         }
 
@@ -98,6 +99,7 @@ class ApiFoodTest extends TestCase
         $this->api->activeTestMode();
         try {
             $prd = $this->api->getProduct('3057640385148');
+            $this->assertInstanceOf(FoodProduct::class, $prd);
             $this->assertInstanceOf(Document::class, $prd);
         } catch (Exception $exception) {
             if ($exception->getPrevious() instanceof ServerException && $exception->getPrevious()->getCode() === 503) {
@@ -195,11 +197,11 @@ class ApiFoodTest extends TestCase
         }
 
         $collection = $this->api->getPurchase_places();
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $collection = $this->api->getPackaging_codes();
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $collection = $this->api->getEntry_dates();
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
 
         try {
             $collection = $this->api->getIngredient();

--- a/tests/ApiFoodTest.php
+++ b/tests/ApiFoodTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
-use OpenFoodFacts\Document\FoodProduct;
+use OpenFoodFacts\Document\FoodDocument;
 use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
@@ -39,7 +39,7 @@ class ApiFoodTest extends TestCase
 
         $prd = $this->api->getProduct('3057640385148');
 
-        $this->assertInstanceOf(FoodProduct::class, $prd);
+        $this->assertInstanceOf(FoodDocument::class, $prd);
         $this->assertInstanceOf(Document::class, $prd);
         $this->assertTrue(isset($prd->product_name));
         $this->assertNotEmpty($prd->product_name);
@@ -88,7 +88,7 @@ class ApiFoodTest extends TestCase
             if ($key > 1) {
                 break;
             }
-            $this->assertInstanceOf(FoodProduct::class, $doc);
+            $this->assertInstanceOf(FoodDocument::class, $doc);
             $this->assertInstanceOf(Document::class, $doc);
 
         }
@@ -100,7 +100,7 @@ class ApiFoodTest extends TestCase
         $this->api->activeTestMode();
         try {
             $prd = $this->api->getProduct('3057640385148');
-            $this->assertInstanceOf(FoodProduct::class, $prd);
+            $this->assertInstanceOf(FoodDocument::class, $prd);
             $this->assertInstanceOf(Document::class, $prd);
         } catch (Exception $exception) {
             if ($exception->getPrevious() instanceof ServerException && $exception->getPrevious()->getCode() === 503) {

--- a/tests/ApiPetTest.php
+++ b/tests/ApiPetTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
 use OpenFoodFacts\Document\PetProduct;
+use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
     BadRequestException

--- a/tests/ApiPetTest.php
+++ b/tests/ApiPetTest.php
@@ -5,8 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
-use OpenFoodFacts\Document;
-use OpenFoodFacts\Document\Product;
+use OpenFoodFacts\Document\PetProduct;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
     BadRequestException
@@ -40,7 +39,8 @@ class ApiPetTest extends TestCase
 
         $prd = $this->api->getProduct('7613035799738');
 
-        $this->assertEquals(get_class($prd), Document::class);
+        $this->assertInstanceOf(PetProduct::class, $prd);
+        $this->assertInstanceOf(Document::class, $prd);
         $this->assertTrue(isset($prd->product_name));
         $this->assertNotEmpty($prd->product_name);
 
@@ -65,7 +65,7 @@ class ApiPetTest extends TestCase
 
         $collection = $this->api->search('chat', 3, 30);
 
-        $this->assertEquals(get_class($collection), Collection::class);
+        $this->assertInstanceOf(Collection::class, $collection);
         $this->assertEquals($collection->pageCount(), 30);
         $this->assertGreaterThan(100, $collection->searchCount());
 

--- a/tests/ApiPetTest.php
+++ b/tests/ApiPetTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 use OpenFoodFacts\Api;
 use OpenFoodFacts\Collection;
-use OpenFoodFacts\Document\PetProduct;
+use OpenFoodFacts\Document\PetDocument;
 use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\{
     ProductNotFoundException,
@@ -40,7 +40,7 @@ class ApiPetTest extends TestCase
 
         $prd = $this->api->getProduct('7613035799738');
 
-        $this->assertInstanceOf(PetProduct::class, $prd);
+        $this->assertInstanceOf(PetDocument::class, $prd);
         $this->assertInstanceOf(Document::class, $prd);
         $this->assertTrue(isset($prd->product_name));
         $this->assertNotEmpty($prd->product_name);


### PR DESCRIPTION
Update:
The code now uses the existing (but unused) specific Document Types depending on the API called.
Former type was "OpenFoodFacts\Document".

The types now used are:
 

- OpenFoodFacts\Document\FoodDocument;

- OpenFoodFacts\Document\PetDocument;

- OpenFoodFacts\Document\BeautyDocument;

- OpenFoodFacts\Document\ProductDocument;

these types extend the old generic "Document"-Type. So checks for the class "Document" are still valid.
This is more a cosmetic code cleaning thing. 


New Functionality: 
**Raw Data**
Document::class->getData();

Returns a alphabetically and numberly ordered array representation of the Document
Helpful for f.e. debugging. 

**Product API**
Added Product API(https://world.openproductsfacts.org/) for usage


 