### PR TITLE
re-add Api-Info into Document

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -228,27 +228,7 @@ class Api
             throw new ProductNotFoundException("Product not found", 1);
         }
 
-        return $this->createSpecificDocument($this->currentAPI, $rawResult['product']);
-    }
-
-    /**
-     * @param string $apiIdentifier
-     * @param array $data
-     * @return Document
-     */
-    protected function createSpecificDocument(string $apiIdentifier, array $data): Document
-    {
-        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Document';
-
-        if (class_exists($className) && is_subclass_of($className, Document::class)) {
-            return new $className($data);
-        } else {
-            $this->logger->error(
-                sprintf('Tried to instanciate "%s", but could not find class or class is not extending %s - Returning: %s', $className, Document::class, Document::class)
-            );
-        }
-
-        return new Document($data);
+        return Document::createSpecificDocument($this->currentAPI, $rawResult['product']);
     }
 
     /**
@@ -347,7 +327,7 @@ class Api
             'page'          => $page,
             'page_size'     => $pageSize,
             'sort_by'       => $sortBy,
-            'json'          => '1'
+            'json'          => '1',
         ];
 
         $url = $this->buildUrl('cgi', 'search.pl', $parameters);

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -35,7 +35,14 @@ class Collection implements Iterator
                 $currentApi = $api;
             }
             foreach ($data['products'] as $document) {
-                $this->listDocuments[] = $this->createSpecificDocument($currentApi, $document);
+                if($document instanceof Document){
+                    $this->listDocuments[] = $document;
+                }elseif (is_array($document)){
+                    $this->listDocuments[] = Document::createSpecificDocument($currentApi, $document);
+                }else {
+                    throw new \InvalidArgumentException(sprintf('Would expect an OpenFoodFacts\Document Interface or Array here. Got: %s', gettype($document)));
+                }
+
             }
         }
 
@@ -43,26 +50,6 @@ class Collection implements Iterator
         $this->page     = $data['page'];
         $this->skip     = $data['skip'];
         $this->pageSize = $data['page_size'];
-    }
-
-    /**
-     * @param string $apiIdentifier
-     * @param array $data
-     * @return Document
-     */
-    protected function createSpecificDocument(string $apiIdentifier, array $data): Document
-    {
-        if ($apiIdentifier === '') {
-            return new Document($data);
-        }
-
-        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Document';
-
-        if (class_exists($className) && is_subclass_of($className, Document::class)) {
-            return new $className($data);
-        }
-
-        return new Document($data);
     }
 
     /**

--- a/src/Document.php
+++ b/src/Document.php
@@ -58,4 +58,26 @@ class Document
         return $this->data;
     }
 
+    /**
+     * Returns a Document in the type regarding to the API used.
+     * May be a Child of "Document" e.g.: FoodDocument or ProductDocument
+     * @param string $apiIdentifier
+     * @param array  $data
+     * @return Document
+     */
+    public static function createSpecificDocument(string $apiIdentifier, array $data): Document
+    {
+        if ($apiIdentifier === '') {
+            return new Document($data, $apiIdentifier);
+        }
+
+        $className = "OpenFoodFacts\Document\\" . ucfirst($apiIdentifier) . 'Document';
+
+        if (class_exists($className) && is_subclass_of($className, Document::class)) {
+            return new $className($data, $apiIdentifier);
+        }
+
+        return new Document($data, $apiIdentifier);
+    }
+
 }


### PR DESCRIPTION
The optional argument "$api" was missing in the specific document creation - this PR - re-adds this and moves the functionality for it into the document itself.