### PR TITLE
Document Testing and Testing on different PHP Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 php:
-  - '7.2'
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
 before_script: composer install --dev
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,6 @@
     "phpunit/phpunit": "^7.0",
     "symfony/cache": "^4.3",
     "monolog/monolog": "^1.23",
-    "ext-gd": ">=7.2"
+    "ext-gd": "*"
   }
 }

--- a/tests/OpenFoodFacts/CollectionTest.php
+++ b/tests/OpenFoodFacts/CollectionTest.php
@@ -4,22 +4,28 @@ use OpenFoodFacts\Collection;
 use OpenFoodFacts\Document;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class CollectionTest
+ */
 class CollectionTest extends TestCase
 {
     public function testConstructorMustPopulateListDocumentWithExistingDocuments()
     {
+
+        $documents = [
+            Document::createSpecificDocument('', []),
+            Document::createSpecificDocument('', []),
+        ];
+
         $collection = new Collection([
-            'products'=> $documents = [
-                Document::createSpecificDocument('', []),
-                Document::createSpecificDocument('', []),
-            ],
+            'products'=> $documents,
             'count' => 2,
             'page' => 1,
             'skip' => false,
             'page_size' => 2,
         ], '');
 
-        $this->assertCount(\count($documents), $collection);
+        $this->assertCount(count($documents), $collection);
         $docs = [];
         foreach($collection as $doc) {
             $docs[] = $doc;

--- a/tests/OpenFoodFacts/DocumentTest.php
+++ b/tests/OpenFoodFacts/DocumentTest.php
@@ -3,8 +3,12 @@
 use OpenFoodFacts\Document;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class DocumentTest
+ */
 class DocumentTest extends TestCase
 {
+
     public function testCreateSpecificDocumentMustCreatedADocumentFromEmptyIdentifier()
     {
         $this->assertInstanceOf(Document::class, Document::createSpecificDocument('', []));
@@ -13,6 +17,19 @@ class DocumentTest extends TestCase
     public function testCreateSpecificDocumentMustCreatedADocumentFromUnknownIdentifier()
     {
         $this->assertInstanceOf(Document::class, Document::createSpecificDocument('unknown', []));
+    }
+
+    public function testCreateSpecificDocumentFromKnownIdentifiers()
+    {
+        $types = [
+            'food'    => Document\FoodDocument::class,
+            'beauty'  => Document\BeautyDocument::class,
+            'pet'     => Document\PetDocument::class,
+            'product' => Document\ProductDocument::class,
+        ];
+        foreach ($types as $type => $className) {
+            $this->assertInstanceOf($className, Document::createSpecificDocument($type, []));
+        }
     }
 
     public function testGetDataMustReturnTheOriginalEmptyArray()
@@ -24,41 +41,94 @@ class DocumentTest extends TestCase
 
     public function testGetDataMustReturnTheNumericKeysArraySorted()
     {
-        $doc = Document::createSpecificDocument('', [
-            1 => 'b',
-            2 => 'c',
-            0 => 'a',
-        ]);
+        $doc = Document::createSpecificDocument(
+            '',
+            [
+                1 => 'b',
+                2 => 'c',
+                0 => 'a',
+            ]
+        );
 
-        $this->assertSame([
-            0 =>  'a',
-            1 =>  'b',
-            2 =>  'c',
-        ], $doc->getData());
+        $this->assertSame(
+            [
+                0 => 'a',
+                1 => 'b',
+                2 => 'c',
+            ],
+            $doc->getData()
+        );
     }
 
     public function testGetDataMustReturnTheStringKeysArraySorted()
     {
-        $doc = Document::createSpecificDocument('', [
-            'b' => 1,
-            'c' => 2,
-            'a' => 0,
-        ]);
+        $doc = Document::createSpecificDocument(
+            '',
+            [
+                'b' => 1,
+                'c' => 2,
+                'a' => 0,
+            ]
+        );
 
-        $this->assertSame([
-            'a' => 0,
-            'b' => 1,
-            'c' => 2,
-        ], $doc->getData());
+        $this->assertSame(
+            [
+                'a' => 0,
+                'b' => 1,
+                'c' => 2,
+            ],
+            $doc->getData()
+        );
+    }
+
+    public function testGetDataMustReturnMultilayerArraySorted(){
+        $doc = Document::createSpecificDocument(
+            '',
+            [
+                'b' => 1,
+                'c' => 2,
+                'a' => 0,
+                'd' => [
+                    'b' => 1,
+                    'c' => 2,
+                    'a' => [
+                        2 => 'a',
+                        1 => 'xyz',
+                        0 => 'c',
+                    ],
+                ],
+            ]
+        );
+
+        $expectedArray =
+            [
+                'a' => 0,
+                'b' => 1,
+                'c' => 2,
+                'd' => [
+                    'a' => [
+                        0 => 'c',
+                        1 => 'xyz',
+                        2 => 'a',
+                    ],
+                    'b' => 1,
+                    'c' => 2,
+                ],
+            ];
+
+        $this->assertSame($expectedArray, $doc->getData());
     }
 
     public function testGetDataMustReturnTheSameArray()
     {
-        $doc = Document::createSpecificDocument('', $data = [
-            0 => 0,
-            1 => 1,
-            2 => 2,
-        ]);
+        $doc = Document::createSpecificDocument(
+            '',
+            $data = [
+                0 => 0,
+                1 => 1,
+                2 => 2,
+            ]
+        );
 
         $this->assertSame($data, $doc->getData());
     }


### PR DESCRIPTION
add Tests for 
- specific document creation
- recursive sorting
- different PHP-Versions 
changed hard versioned dev-dependency on ext-gd in composer - as it's bound to the PHP-Version in use and the package requires ">=7.1"

fixes #20 