### PR TITLE
chore!: Upgrade dependencies (dropping < PHP8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['8.0', '8.1']
     name: Tests - PHP ${{ matrix.php }} 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "ext-json": "*",
     "ext-curl": "*",
     "guzzlehttp/guzzle": "^6.3|^7.0",
-    "psr/log": "^1.0",
-    "psr/simple-cache": "^1.0"
+    "psr/log": "^1.0|^2.0|^3.0",
+    "psr/simple-cache": "^1.0|^2.0|^3.0"
   },
   "autoload": {
     "psr-4": {
@@ -36,8 +36,8 @@
   },
   "require-dev": {
     "ext-gd": "*",
-    "monolog/monolog": "^1.23",
-    "symfony/cache": "^4.3",
+    "monolog/monolog": "^2.8",
+    "symfony/cache": "^6.0",
     "phpunit/phpunit": "^8.5|^9.5",
     "phpstan/phpstan": "^0.12.99",
     "phpstan/phpstan-phpunit": "^0.12.22",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
   },
   "require-dev": {
     "ext-gd": "*",
-    "monolog/monolog": "^2.8",
     "symfony/cache": "^6.0",
     "phpunit/phpunit": "^8.5|^9.5",
     "phpstan/phpstan": "^1.8.2",

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
     "monolog/monolog": "^2.8",
     "symfony/cache": "^6.0",
     "phpunit/phpunit": "^8.5|^9.5",
-    "phpstan/phpstan": "^0.12.99",
-    "phpstan/phpstan-phpunit": "^0.12.22",
+    "phpstan/phpstan": "^1.8.2",
+    "phpstan/phpstan-phpunit": "^1.1.1",
     "friendsofphp/php-cs-fixer": "^3.1"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": "^7.2|^8.0",
+    "php": "^8.0.2",
     "ext-json": "*",
     "ext-curl": "*",
     "guzzlehttp/guzzle": "^6.3|^7.0",

--- a/examples/01-basic_api_usage/cached_example.php
+++ b/examples/01-basic_api_usage/cached_example.php
@@ -4,7 +4,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 
 include '../../vendor/autoload.php';
-$logger     = new \Monolog\Logger('test');
+$logger     = new \Psr\Log\NullLogger;
 $httpClient = new \GuzzleHttp\Client();
 // the PSR-6 cache object that you want to use (you might also use a PSR-16 Interface Object directly)
 $psr6Cache  = new FilesystemAdapter();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,7 @@ parameters:
   checkMissingIterableValueType: false
   ignoreErrors:
     - '/.*is not subtype of Throwable/'
+  reportUnmatchedIgnoredErrors: false
   paths:
     - src
     - tests

--- a/src/Api.php
+++ b/src/Api.php
@@ -45,19 +45,6 @@ class Api
     private $currentAPI = '';
 
     /**
-     * This property store the current location for http call
-     *
-     * This property could be world for all product or you can specify le country code (cc) and
-     * language of the interface (lc). If you want filter on french product you can set fr as country code.
-     * We strongly recommend to use english as language of the interface
-     *
-     * @example fr-en
-     * @link https://en.wiki.openfoodfacts.org/API/Read#Country_code_.28cc.29_and_Language_of_the_interface_.28lc.29
-     * @var string
-     */
-    private $geography  = 'world';
-
-    /**
      * this property store the auth parameter (username and password)
      * @var array
      */
@@ -146,7 +133,6 @@ class Api
         $this->httpClient   = $clientInterface ?? new Client();
 
         $this->geoUrl     = sprintf(self::LIST_API[$api], $geography);
-        $this->geography  = $geography;
         $this->currentAPI = $api;
     }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -324,10 +324,10 @@ class Api
 
         try {
             return $this->fetchPost($url, $postData, true);
-        } catch (\Exception $e) {
-            fclose($postData['imgupload_' . $imageField]);
-
-            throw $e;
+        } finally {
+            if (is_resource($postData['imgupload_' . $imageField])) {
+                fclose($postData['imgupload_' . $imageField]);
+            }
         }
     }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -321,7 +321,14 @@ class Api
             'imagefield'                => $imageField,
             'imgupload_' . $imageField  => fopen($imagePath, 'r')
         ];
-        return $this->fetchPost($url, $postData, true);
+
+        try {
+            return $this->fetchPost($url, $postData, true);
+        } catch (\Exception $e) {
+            fclose($postData['imgupload_' . $imageField]);
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Api.php
+++ b/src/Api.php
@@ -45,6 +45,20 @@ class Api
     private $currentAPI = '';
 
     /**
+     * This property store the current location for http call
+     *
+     * This property could be world for all product or you can specify le country code (cc) and
+     * language of the interface (lc). If you want filter on french product you can set fr as country code.
+     * We strongly recommend to use english as language of the interface
+     *
+     * @example fr-en
+     * @link https://en.wiki.openfoodfacts.org/API/Read#Country_code_.28cc.29_and_Language_of_the_interface_.28lc.29
+     * @var string
+     */
+    /** @phpstan-ignore-next-line */
+    private $geography  = 'world';
+
+    /**
      * this property store the auth parameter (username and password)
      * @var array
      */
@@ -133,6 +147,7 @@ class Api
         $this->httpClient   = $clientInterface ?? new Client();
 
         $this->geoUrl     = sprintf(self::LIST_API[$api], $geography);
+        $this->geography  = $geography;
         $this->currentAPI = $api;
     }
 
@@ -393,7 +408,7 @@ class Api
 
         if (!empty($this->cache) && $this->cache->has($cacheKey)) {
             $cachedResult = $this->cache->get($cacheKey);
-            return $cachedResult;
+            return (array)$cachedResult;
         }
 
         $data = [
@@ -427,7 +442,7 @@ class Api
             $this->cache->set($cacheKey, $jsonResult);
         }
 
-        return $jsonResult;
+        return (array)$jsonResult;
     }
 
     /**
@@ -459,7 +474,7 @@ class Api
         $cacheKey = md5($url . json_encode($data));
 
         if (!empty($this->cache) && $this->cache->has($cacheKey)) {
-            return $this->cache->get($cacheKey);
+            return (array)$this->cache->get($cacheKey);
         }
 
         try {
@@ -478,7 +493,7 @@ class Api
             $this->cache->set($cacheKey, $jsonResult);
         }
 
-        return $jsonResult;
+        return (array)$jsonResult;
     }
 
     /**
@@ -493,15 +508,17 @@ class Api
         $baseUrl = null;
         switch ($service) {
             case 'api':
+                /** @phpstan-ignore-next-line */
                 $baseUrl = implode('/', [
-                  $this->geoUrl,
-                  $service,
-                  'v0',
-                  $resourceType,
-                  $parameters
+                    $this->geoUrl,
+                    $service,
+                    'v0',
+                    $resourceType,
+                    $parameters
                 ]);
                 break;
             case 'data':
+                /** @phpstan-ignore-next-line */
                 $baseUrl = implode('/', [
                   $this->geoUrl,
                   $service,
@@ -509,6 +526,7 @@ class Api
                 ]);
                 break;
             case 'cgi':
+                /** @phpstan-ignore-next-line */
                 $baseUrl = implode('/', [
                   $this->geoUrl,
                   $service,
@@ -526,6 +544,7 @@ class Api
                     $resourceType = implode('/', ["state",  "ingredients-completed"]);
                     $parameters   = 1;
                 }
+                /** @phpstan-ignore-next-line */
                 $baseUrl = implode('/', array_filter([
                     $this->geoUrl,
                     $resourceType,

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -103,7 +103,7 @@ class Collection implements \Iterator
     /**
      * @inheritDoc
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->listDocuments);
     }
@@ -125,16 +125,15 @@ class Collection implements \Iterator
     }
     /**
      * @inheritDoc
-     * @return Document|false
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->listDocuments);
+        next($this->listDocuments);
     }
     /**
      * @inheritDoc
      */
-    public function valid()
+    public function valid(): bool
     {
         $key = key($this->listDocuments);
         return ($key !== null && $key !== false);

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -111,7 +111,7 @@ class Collection implements \Iterator
      * @inheritDoc
      * @return Document|false
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->listDocuments);
     }
@@ -119,7 +119,7 @@ class Collection implements \Iterator
      * @inheritDoc
      * @return int|null
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->listDocuments);
     }

--- a/src/Document.php
+++ b/src/Document.php
@@ -22,6 +22,7 @@ class Document
      * the whole data
      * @var string|null
      */
+    /** @phpstan-ignore-next-line */
     private $api;
 
     /**

--- a/tests/ApiFoodTest.php
+++ b/tests/ApiFoodTest.php
@@ -11,7 +11,7 @@ use OpenFoodFacts\Document\FoodDocument;
 use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\ProductNotFoundException;
 use OpenFoodFacts\Exception\BadRequestException;
-use Monolog\Logger;
+use Psr\Log\NullLogger;
 
 class ApiFoodTest extends TestCase
 {
@@ -20,13 +20,13 @@ class ApiFoodTest extends TestCase
     /** @var Api */
     protected $api;
     /**
-     * @var Logger|MockObject
+     * @var NullLogger|MockObject
      */
     protected $log;
 
     protected function setUp(): void
     {
-        $this->log = $this->createMock(Logger::class);
+        $this->log = $this->createMock(NullLogger::class);
 
         $this->api = new Api('food', 'fr-en', $this->log);
         @rmdir('tests/tmp');

--- a/tests/ApiPetTest.php
+++ b/tests/ApiPetTest.php
@@ -9,7 +9,7 @@ use OpenFoodFacts\Collection;
 use OpenFoodFacts\Document\PetDocument;
 use OpenFoodFacts\Document;
 use OpenFoodFacts\Exception\BadRequestException;
-use Monolog\Logger;
+use Psr\Log\NullLogger;
 
 class ApiPetTest extends TestCase
 {
@@ -20,7 +20,7 @@ class ApiPetTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->api = new Api('pet', 'fr', $this->createMock(Logger::class));
+        $this->api = new Api('pet', 'fr', $this->createMock(NullLogger::class));
 
         foreach (glob('tests/images/*') ?: [] as $file) {
             unlink($file);


### PR DESCRIPTION
to support apps that require PHP8 as a minimum, the following dependencies needed to be bumped/widened:

- require PHP8 min.
- psr/log
- psr/simple-cache
- (dev) monolog/monolog
- (dev) symfony/cache

[OT] also included: small fix to release file handle when `uploadImage()` fails

When this PR is approved, I suggest we immediately tag and release as a new version (0.3.0) in order for the `openfoodfacts/openfoodfacts-laravel` repo to allow it to require it as a minimum, because that one is currently failing Laravel 9 support without this PR's changes (as addressed in https://github.com/openfoodfacts/openfoodfacts-laravel/issues/26).

