### PR TITLE
fix: .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/17](https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/17)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `tests`) unless overridden.  
For this CI workflow, the best minimal safe setting is:

- `contents: read`

This supports code checkout and typical read-only CI operations while preventing unintended token write capabilities.

**Where to change:** `.github/workflows/ci.yml`, immediately after the `on:` trigger block (before `jobs:`).

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
