### PR TITLE
fix: .github/workflows/release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@
    push:
      branches:
        - develop
+ permissions:
+   contents: write
+   pull-requests: write
  jobs:
    release-please:
      runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/15](https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/15)

Add an explicit `permissions` block to `.github/workflows/release-please.yml`.  
Best fix without changing behavior: define permissions at the workflow root so they apply to all jobs (currently only one job). For `release-please-action`, minimally include:
- `contents: write` (create/update releases/tags/changelog commits as needed)
- `pull-requests: write` (open/update release PRs)

Place this block after the `on:` trigger section and before `jobs:`.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
