### PR TITLE
fix: .github/workflows/semantic-pr.yml

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/12](https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/12)

Add an explicit `permissions` block to `.github/workflows/semantic-pr.yml` to enforce least privilege for `GITHUB_TOKEN`.  
Best fix (without changing behavior): set workflow-level permissions to only what this PR-title validation needs:

- `contents: read`
- `pull-requests: read`

This keeps functionality (reading PR metadata/title) while preventing unnecessary write access.  
Edit location: directly under the `on:` trigger block and before `jobs:` in `.github/workflows/semantic-pr.yml`.  
No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
