### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -9,6 +9,7 @@ on:
     types:
       - opened
       - labeled
+permissions: {}
 jobs:
   add-to-project:
     name: Add issue to the relevant GitHub Project


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/3](https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is not implicitly granted default repository permissions.

Best minimal, non-breaking fix:
- Edit **`.github/workflows/github-projects.yml`**
- Add a top-level `permissions: {}` block between `on:` and `jobs:` (or after `name:`/`on:`).  
  This sets all `GITHUB_TOKEN` scopes to none for all jobs in this workflow.
- This is safe here because the job uses `secrets.ADD_TO_PROJECT_PAT` for all add-to-project operations, so functionality should remain unchanged.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
