### PR TITLE
fix: .github/workflows/merge-conflict-autolabel.yml

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -7,6 +7,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
   
 jobs:
   triage:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/2](https://github.com/openfoodfacts/openfoodfacts-php/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so all jobs inherit least privilege by default, while granting the minimum write scope needed for labeling PRs.

Best single fix (without changing functionality):
- Edit `.github/workflows/merge-conflict-autolabel.yml`.
- Add a root-level `permissions` block after `concurrency` (or before `jobs`), with:
  - `contents: read` (safe minimal read access)
  - `pull-requests: write` (needed to add labels on PRs)

No imports, methods, or dependencies are needed; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
